### PR TITLE
PROXI-68: Correct worker count when using --worker option

### DIFF
--- a/app/utils/initialization.py
+++ b/app/utils/initialization.py
@@ -353,4 +353,5 @@ def get_number_of_workers() -> int:
     workers = [
         p for p in parent_process.children() if p.status() != psutil.STATUS_ZOMBIE
     ]
-    return len(workers)
+    # We remove the parent process from the list of workers, as it does not process any job
+    return len(workers) - 1


### PR DESCRIPTION
### Description

Please explain the changes you made here.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the documentation, if necessary
