### PR TITLE
Asynchronous file manipulation based on anyio

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4,12 +4,12 @@ import logging
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import alembic.command as alembic_command
 import alembic.config as alembic_config
 import alembic.migration as alembic_migration
+from anyio import Path
 from calypsso import get_calypsso_app
 from fastapi import FastAPI, HTTPException, Request, Response, status
 from fastapi.encoders import jsonable_encoder
@@ -475,7 +475,7 @@ async def init_google_API(
             pass
 
 
-def test_configuration(
+async def test_configuration(
     settings: Settings,
     hyperion_error_logger: logging.Logger,
 ) -> None:
@@ -499,9 +499,9 @@ def test_configuration(
             )
 
     # Create folder for calendars if they don't already exists
-    Path("data/ics/").mkdir(parents=True, exist_ok=True)
-    Path("data/core/").mkdir(parents=True, exist_ok=True)
-    Path("data/campaigns/").mkdir(parents=True, exist_ok=True)
+    await Path("data/ics/").mkdir(parents=True, exist_ok=True)
+    await Path("data/core/").mkdir(parents=True, exist_ok=True)
+    await Path("data/campaigns/").mkdir(parents=True, exist_ok=True)
 
 
 async def init_lifespan(

--- a/app/core/associations/endpoints_associations.py
+++ b/app/core/associations/endpoints_associations.py
@@ -215,7 +215,7 @@ async def read_association_logo(
     if not association:
         raise HTTPException(status_code=404, detail="Association not found")
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="associations/logos",
         filename=association_id,
         raise_http_exception=True,

--- a/app/core/core_endpoints/endpoints_core.py
+++ b/app/core/core_endpoints/endpoints_core.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-
+from anyio import Path
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import FileResponse
 
@@ -45,13 +44,13 @@ async def read_information(
     "/privacy",
     status_code=200,
 )
-def read_privacy(settings: Settings = Depends(get_settings)):
+async def read_privacy(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion privacy
     """
 
     return patch_identity_in_text(
-        Path("assets/privacy.txt").read_text(encoding="utf-8"),
+        await Path("assets/privacy.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -60,13 +59,13 @@ def read_privacy(settings: Settings = Depends(get_settings)):
     "/terms-and-conditions",
     status_code=200,
 )
-def read_terms_and_conditions(settings: Settings = Depends(get_settings)):
+async def read_terms_and_conditions(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion terms and conditions pages
     """
 
     return patch_identity_in_text(
-        Path("assets/terms-and-conditions.txt").read_text(encoding="utf-8"),
+        await Path("assets/terms-and-conditions.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -75,12 +74,12 @@ def read_terms_and_conditions(settings: Settings = Depends(get_settings)):
     "/mypayment-terms-of-service",
     status_code=200,
 )
-def read_mypayment_tos(settings: Settings = Depends(get_settings)):
+async def read_mypayment_tos(settings: Settings = Depends(get_settings)):
     """
     Return MyPayment latest ToS
     """
     return patch_identity_in_text(
-        Path("assets/mypayment-terms-of-service.txt").read_text(encoding="utf-8"),
+        await Path("assets/mypayment-terms-of-service.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -89,13 +88,13 @@ def read_mypayment_tos(settings: Settings = Depends(get_settings)):
     "/support",
     status_code=200,
 )
-def read_support(settings: Settings = Depends(get_settings)):
+async def read_support(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion support
     """
 
     return patch_identity_in_text(
-        Path("assets/support.txt").read_text(encoding="utf-8"),
+        await Path("assets/support.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -104,12 +103,12 @@ def read_support(settings: Settings = Depends(get_settings)):
     "/security.txt",
     status_code=200,
 )
-def read_security_txt(settings: Settings = Depends(get_settings)):
+async def read_security_txt(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion security.txt file
     """
     return patch_identity_in_text(
-        Path("assets/security.txt").read_text(encoding="utf-8"),
+        await Path("assets/security.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -118,13 +117,13 @@ def read_security_txt(settings: Settings = Depends(get_settings)):
     "/.well-known/security.txt",
     status_code=200,
 )
-def read_wellknown_security_txt(settings: Settings = Depends(get_settings)):
+async def read_wellknown_security_txt(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion security.txt file
     """
 
     return patch_identity_in_text(
-        Path("assets/security.txt").read_text(encoding="utf-8"),
+        await Path("assets/security.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -133,13 +132,13 @@ def read_wellknown_security_txt(settings: Settings = Depends(get_settings)):
     "/robots.txt",
     status_code=200,
 )
-def read_robots_txt(settings: Settings = Depends(get_settings)):
+async def read_robots_txt(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion robots.txt file
     """
 
     return patch_identity_in_text(
-        Path("assets/robots.txt").read_text(encoding="utf-8"),
+        await Path("assets/robots.txt").read_text(encoding="utf-8"),
         settings,
     )
 
@@ -148,13 +147,13 @@ def read_robots_txt(settings: Settings = Depends(get_settings)):
     "/account-deletion",
     status_code=200,
 )
-def read_account_deletion(settings: Settings = Depends(get_settings)):
+async def read_account_deletion(settings: Settings = Depends(get_settings)):
     """
     Return Hyperion account deletion information
     """
 
     return patch_identity_in_text(
-        Path("assets/account-deletion.md").read_text(encoding="utf-8"),
+        await Path("assets/account-deletion.md").read_text(encoding="utf-8"),
         settings,
     )
 

--- a/app/core/mypayment/endpoints_mypayment.py
+++ b/app/core/mypayment/endpoints_mypayment.py
@@ -4,10 +4,10 @@ import re
 import urllib.parse
 import uuid
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from uuid import UUID
 
 import calypsso
+from anyio import Path
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -1418,7 +1418,7 @@ async def get_user_tos(
         accepted_tos_version=existing_user_payment.accepted_tos_version,
         latest_tos_version=LATEST_TOS,
         tos_content=patch_identity_in_text(
-            Path("assets/mypayment-terms-of-service.txt").read_text(),
+            await Path("assets/mypayment-terms-of-service.txt").read_text(),
             settings=settings,
         ),
         max_wallet_balance=settings.MYPAYMENT_MAXIMUM_WALLET_BALANCE,
@@ -3112,7 +3112,7 @@ async def download_invoice(
             status_code=403,
             detail="User is not allowed to access this invoice",
         )
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="mypayment/invoices",
         filename=invoice_id,
     )

--- a/app/core/users/endpoints_users.py
+++ b/app/core/users/endpoints_users.py
@@ -3,8 +3,8 @@ import string
 import uuid
 from datetime import UTC, datetime, timedelta
 
-import aiofiles
 import calypsso
+from anyio import Path
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -874,8 +874,8 @@ async def migrate_mail_confirm(
         db=db,
     )
 
-    async with aiofiles.open(
-        "data/core/mail-migration-archives.txt",
+    path = Path("data/core/mail-migration-archives.txt")
+    async with await path.open(
         mode="a",
     ) as file:
         await file.write(
@@ -1143,7 +1143,7 @@ async def read_own_profile_picture(
     Get the profile picture of the authenticated user.
     """
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="profile-pictures",
         filename=str(user.id),
         default_asset="assets/images/default_profile_picture.png",
@@ -1169,7 +1169,7 @@ async def read_user_profile_picture(
     if not db_user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="profile-pictures",
         filename=str(user_id),
         default_asset="assets/images/default_profile_picture.png",

--- a/app/core/utils/config.py
+++ b/app/core/utils/config.py
@@ -1,5 +1,5 @@
+import pathlib
 from functools import cached_property
-from pathlib import Path
 from re import Pattern
 from typing import Any, ClassVar
 
@@ -360,14 +360,14 @@ class Settings(BaseSettings):
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def HYPERION_VERSION(cls) -> str:
-        with Path("pyproject.toml").open("rb") as pyproject_binary:
+        with pathlib.Path("pyproject.toml").open("rb") as pyproject_binary:
             pyproject = tomllib.load(pyproject_binary)
         return str(pyproject["project"]["version"])
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def MINIMAL_TITAN_VERSION_CODE(cls) -> int:
-        with Path("pyproject.toml").open("rb") as pyproject_binary:
+        with pathlib.Path("pyproject.toml").open("rb") as pyproject_binary:
             pyproject = tomllib.load(pyproject_binary)
         return int(pyproject["tool"]["titan"]["minimal-titan-version-code"])
 

--- a/app/modules/advert/endpoints_advert.py
+++ b/app/modules/advert/endpoints_advert.py
@@ -305,7 +305,7 @@ async def read_advert_image(
             detail="The advert does not exist",
         )
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="adverts",
         filename=advert_id,
         raise_http_exception=True,

--- a/app/modules/calendar/endpoints_calendar.py
+++ b/app/modules/calendar/endpoints_calendar.py
@@ -624,7 +624,7 @@ async def delete_event(
             status=NewsStatus.REJECTED,
             db=db,
         )
-        delete_file_from_data(
+        await delete_file_from_data(
             directory="event",
             filename=event_id,
         )

--- a/app/modules/calendar/utils_calendar.py
+++ b/app/modules/calendar/utils_calendar.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from uuid import UUID
 
-import aiofiles
+from anyio import Path
 from icalendar import Calendar, Event, vRecur
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -104,5 +104,5 @@ async def create_icalendar_file(
 
             calendar.add_component(ical_event)
 
-    async with aiofiles.open(calendar_file_path, mode="wb") as calendar_file:
+    async with await Path(calendar_file_path).open(mode="wb") as calendar_file:
         await calendar_file.write(calendar.to_ical())

--- a/app/modules/campaign/endpoints_campaign.py
+++ b/app/modules/campaign/endpoints_campaign.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
-import aiofiles
+from anyio import Path
 from fastapi import Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -493,8 +493,8 @@ async def open_vote(
 
     # Archive all changes to a json file
     lists = await cruds_campaign.get_lists(db=db)
-    async with aiofiles.open(
-        f"data/campaigns/lists-{datetime.now(tz=UTC).date().isoformat()}.json",
+    path = Path(f"data/campaigns/lists-{datetime.now(UTC).date().isoformat()}.json")
+    async with await path.open(
         mode="w",
     ) as file:
         await file.write(json.dumps([liste.as_dict() for liste in lists]))
@@ -610,8 +610,8 @@ async def reset_vote(
 
     # Archive results to a json file
     results = await get_results(db=db, user=user)
-    async with aiofiles.open(
-        f"data/campaigns/results-{datetime.now(UTC).date().isoformat()}.json",
+    path = Path(f"data/campaigns/results-{datetime.now(UTC).date().isoformat()}.json")
+    async with await path.open(
         mode="w",
     ) as file:
         await file.write(
@@ -895,7 +895,7 @@ async def read_campaigns_logo(
             detail="The list does not exist.",
         )
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="campaigns",
         filename=str(list_id),
         default_asset="assets/images/default_campaigns_logo.png",

--- a/app/modules/cinema/endpoints_cinema.py
+++ b/app/modules/cinema/endpoints_cinema.py
@@ -275,7 +275,7 @@ async def read_session_poster(
             detail="The session does not exist.",
         )
 
-    return get_file_from_data(
+    return await get_file_from_data(
         default_asset="assets/images/default_movie.png",
         directory="cinemasessions",
         filename=str(session_id),

--- a/app/modules/ph/endpoints_ph.py
+++ b/app/modules/ph/endpoints_ph.py
@@ -73,7 +73,7 @@ async def get_paper_pdf(
             detail="The paper does not exist.",
         )
 
-    return get_file_from_data(
+    return await get_file_from_data(
         default_asset="assets/pdf/default_ph.pdf",
         directory="ph/pdf",
         filename=str(paper_id),
@@ -228,7 +228,7 @@ async def get_cover(
             detail="The paper does not exist.",
         )
 
-    return get_file_from_data(
+    return await get_file_from_data(
         default_asset="assets/images/default_cover.jpeg",
         directory="ph/cover",
         filename=str(paper_id),
@@ -279,12 +279,12 @@ async def delete_paper(
             detail="Invalid paper_id",
         )
 
-    delete_file_from_data(
+    await delete_file_from_data(
         directory="ph/pdf",
         filename=str(paper_id),
     )
 
-    delete_file_from_data(
+    await delete_file_from_data(
         directory="ph/cover",
         filename=str(paper_id),
     )

--- a/app/modules/phonebook/endpoints_phonebook.py
+++ b/app/modules/phonebook/endpoints_phonebook.py
@@ -837,7 +837,7 @@ async def read_association_logo(
     if association is None:
         raise HTTPException(404, "The Association does not exist.")
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="associations",
         filename=association_id,
         default_asset="assets/images/default_association_picture.png",

--- a/app/modules/raffle/endpoints_raffle.py
+++ b/app/modules/raffle/endpoints_raffle.py
@@ -287,7 +287,7 @@ async def read_raffle_logo(
     if not raffle:
         raise HTTPException(status_code=404, detail="Raffle not found")
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="raffle-pictures",
         filename=str(raffle_id),
         default_asset="assets/images/default_raffle_logo.png",
@@ -845,7 +845,7 @@ async def read_prize_logo(
     if not prize:
         raise HTTPException(status_code=404, detail="Prize not found")
 
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="raffle-prize_picture",
         filename=str(prize_id),
         default_asset="assets/images/default_prize_picture.png",

--- a/app/modules/raid/endpoints_raid.py
+++ b/app/modules/raid/endpoints_raid.py
@@ -1,8 +1,8 @@
 import logging
 import uuid
 from datetime import UTC, date, datetime
-from pathlib import Path
 
+from anyio import Path
 from fastapi import Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -391,7 +391,7 @@ async def delete_all_teams(
     # Delete all participants from the database
     await cruds_raid.delete_all_participant(db)
 
-    delete_all_folder_from_data("raid")
+    await delete_all_folder_from_data("raid")
 
 
 @module.router.post(
@@ -477,8 +477,8 @@ async def read_document(
         # The document can be a global document
         information = await get_core_data(coredata_raid.RaidInformation, db)
         if document_id in {information.raid_rules_id, information.raid_information_id}:
-            return get_file_from_data(
-                default_asset="assets/pdf/default_pdf.pdf",
+            return await get_file_from_data(
+                default_asset="assets/pdf/default_PDF.pdf",
                 directory="raid",
                 filename=str(document_id),
             )
@@ -501,7 +501,7 @@ async def read_document(
             detail="The owner of this document is not a member of your team.",
         )
 
-    return get_file_from_data(
+    return await get_file_from_data(
         default_asset="assets/images/default_advert.png",  # TODO: get a default document
         directory="raid",
         filename=str(document_id),

--- a/app/modules/raid/utils/utils_raid.py
+++ b/app/modules/raid/utils/utils_raid.py
@@ -3,9 +3,9 @@ import zipfile
 
 # import uuid
 from datetime import UTC, date, datetime
-from pathlib import Path
 
 import fitz
+from anyio import Path
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -220,7 +220,7 @@ async def get_all_security_files_zip(
 
     # TODO: delete the previous zip?
     # TODO: iotemp file?
-    Path("data/raid/").mkdir(parents=True, exist_ok=True)
+    await Path("data/raid/").mkdir(parents=True, exist_ok=True)
     zip_file_path = f"data/raid/Fiches_Sécurité_{datetime.now(UTC).strftime('%Y-%m-%d_%H_%M_%S')}.zip"
     with zipfile.ZipFile(
         zip_file_path,
@@ -233,7 +233,7 @@ async def get_all_security_files_zip(
                     information,
                     team.number,
                 )
-                src_pdf = get_file_path_from_data(
+                src_pdf = await get_file_path_from_data(
                     directory="raid/security_file",
                     filename=file_id,
                 )
@@ -260,7 +260,7 @@ async def get_all_team_files_zip(
 
     # TODO: delete the previous zip?
     # TODO: iotemp file?
-    Path("data/raid/").mkdir(parents=True, exist_ok=True)
+    await Path("data/raid/").mkdir(parents=True, exist_ok=True)
     zip_file_path = (
         f"data/raid/Teams_{datetime.now(UTC).strftime('%Y-%m-%d_%H_%M_%S')}.zip"
     )
@@ -272,7 +272,7 @@ async def get_all_team_files_zip(
             file_id = await generate_recap_file_pdf(
                 team,
             )
-            src_pdf = get_file_path_from_data(
+            src_pdf = await get_file_path_from_data(
                 directory="raid/recap",
                 filename=file_id,
             )

--- a/app/modules/recommendation/endpoints_recommendation.py
+++ b/app/modules/recommendation/endpoints_recommendation.py
@@ -172,7 +172,7 @@ async def read_recommendation_image(
     if not recommendation:
         raise HTTPException(status_code=404, detail="The recommendation does not exist")
 
-    return get_file_from_data(
+    return await get_file_from_data(
         default_asset="assets/images/default_recommendation.png",
         directory="recommendations",
         filename=str(recommendation_id),

--- a/app/modules/sport_competition/endpoints_sport_competition.py
+++ b/app/modules/sport_competition/endpoints_sport_competition.py
@@ -2073,7 +2073,7 @@ async def download_participant_certificate(
             status_code=404,
             detail="No certificate uploaded for this participant",
         )
-    return get_file_from_data(
+    return await get_file_from_data(
         directory="sport_competition/certificates",
         filename=str(participant.certificate_file_id),
     )
@@ -2355,7 +2355,7 @@ async def withdraw_from_sport(
         db,
     )
     if participant.certificate_file_id is not None:
-        delete_file_from_data(
+        await delete_file_from_data(
             directory="sport_competition/certificates",
             filename=str(participant.certificate_file_id),
         )
@@ -2435,7 +2435,7 @@ async def delete_participant(
         db,
     )
     if participant.certificate_file_id is not None:
-        delete_file_from_data(
+        await delete_file_from_data(
             directory="sport_competition/certificates",
             filename=str(participant.certificate_file_id),
         )
@@ -2480,7 +2480,7 @@ async def delete_participant_certificate_file(
             None,
             db,
         )
-        delete_file_from_data(
+        await delete_file_from_data(
             directory="sport_competition/certificates",
             filename=str(participant.certificate_file_id),
         )

--- a/app/utils/tools.py
+++ b/app/utils/tools.py
@@ -298,7 +298,7 @@ async def save_bytes_as_data(
     file_bytes: bytes,
     directory: str,
     filename: str | UUID,
-    extension: str,
+    extension: ContentType,
 ):
     """
     Save bytes in file in the data folder.
@@ -328,7 +328,9 @@ async def save_bytes_as_data(
         async for filePath in Path().glob(f"data/{directory}/{filename}.*"):
             await filePath.unlink()
 
-        async with await Path(f"data/{directory}/{filename}.{extension}").open(
+        async with await Path(
+            f"data/{directory}/{filename}.{extension.extension}",
+        ).open(
             mode="wb",
         ) as buffer:
             await buffer.write(file_bytes)
@@ -475,7 +477,7 @@ async def generate_pdf_from_template(
         file_bytes=pdf,
         directory=directory,
         filename=filename,
-        extension="pdf",
+        extension=ContentType.pdf,
     )
 
 
@@ -531,7 +533,7 @@ async def save_pdf_first_page_as_image(
             file_bytes=cover_bytes,
             directory=output_image_directory,
             filename=filename,
-            extension="jpg",
+            extension=ContentType.jpg,
         )
 
 
@@ -645,7 +647,7 @@ async def compress_and_save_image_file(
         file_bytes=original_file_bytes,
         directory=original_directory,
         filename=filename,
-        extension=ContentType(upload_file.content_type).extension,
+        extension=ContentType(upload_file.content_type),
     )
 
     file_bytes = compress_image(

--- a/app/utils/tools.py
+++ b/app/utils/tools.py
@@ -8,13 +8,12 @@ import unicodedata
 from collections.abc import Callable, Sequence
 from inspect import iscoroutinefunction
 from io import BytesIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 from uuid import UUID
 
-import aiofiles
 import calypsso
 import fitz
+from anyio import Path
 from fastapi import HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.templating import Jinja2Templates
@@ -276,14 +275,13 @@ async def save_file_as_data(
     # Remove the existing file if any and create the new one
 
     # If the directory does not exist, we want to create it
-    Path(f"data/{directory}/").mkdir(parents=True, exist_ok=True)
+    await Path(f"data/{directory}/").mkdir(parents=True, exist_ok=True)
 
     try:
-        for filePath in Path().glob(f"data/{directory}/{filename}.*"):
-            filePath.unlink()
+        async for filePath in Path().glob(f"data/{directory}/{filename}.*"):
+            await filePath.unlink()
 
-        async with aiofiles.open(
-            f"data/{directory}/{filename}.{extension}",
+        async with await Path(f"data/{directory}/{filename}.{extension}").open(
             mode="wb",
         ) as buffer:
             # https://stackoverflow.com/questions/63580229/how-to-save-uploadfile-in-fastapi
@@ -324,14 +322,13 @@ async def save_bytes_as_data(
         raise FileNameIsNotAnUUIDError()
 
     # If the directory does not exist, we want to create it
-    Path(f"data/{directory}/").mkdir(parents=True, exist_ok=True)
+    await Path(f"data/{directory}/").mkdir(parents=True, exist_ok=True)
 
     try:
-        for filePath in Path().glob(f"data/{directory}/{filename}.*"):
-            filePath.unlink()
+        async for filePath in Path().glob(f"data/{directory}/{filename}.*"):
+            await filePath.unlink()
 
-        async with aiofiles.open(
-            f"data/{directory}/{filename}.{extension}",
+        async with await Path(f"data/{directory}/{filename}.{extension}").open(
             mode="wb",
         ) as buffer:
             await buffer.write(file_bytes)
@@ -343,7 +340,7 @@ async def save_bytes_as_data(
         raise
 
 
-def get_file_path_from_data(
+async def get_file_path_from_data(
     directory: str,
     filename: str | UUID,
     default_asset: str | None = None,
@@ -369,7 +366,7 @@ def get_file_path_from_data(
         )
         raise FileNameIsNotAnUUIDError()
 
-    for filePath in Path().glob(f"data/{directory}/{filename}.*"):
+    async for filePath in Path().glob(f"data/{directory}/{filename}.*"):
         return filePath
 
     if default_asset is not None:
@@ -381,7 +378,7 @@ def get_file_path_from_data(
     raise FileDoesNotExistError(name=f"{directory}/{filename}.*")
 
 
-def get_file_from_data(
+async def get_file_from_data(
     directory: str,
     filename: str | UUID,
     default_asset: str | None = None,
@@ -396,7 +393,7 @@ def get_file_from_data(
 
     WARNING: **NEVER** trust user input when calling this function. Always check that parameters are valid.
     """
-    path = get_file_path_from_data(
+    path = await get_file_path_from_data(
         directory,
         filename,
         default_asset,
@@ -406,9 +403,9 @@ def get_file_from_data(
     return FileResponse(path)
 
 
-def delete_file_from_data(
+async def delete_file_from_data(
     directory: str,
-    filename: str,
+    filename: str | UUID,
 ):
     """
     Delete all files with the provided filename in the data folder.
@@ -418,24 +415,27 @@ def delete_file_from_data(
 
     WARNING: **NEVER** trust user input when calling this function. Always check that parameters are valid.
     """
+    if isinstance(filename, UUID):
+        filename = str(filename)
+
     if not uuid_regex.match(filename):
         hyperion_error_logger.error(
             f"get_file_from_data: security issue, the filename is not a valid UUID: {filename}. This mean that the user input was not properly checked.",
         )
         raise FileNameIsNotAnUUIDError()
 
-    for filePath in Path().glob(f"data/{directory}/{filename}.*"):
-        filePath.unlink()
+    async for filePath in Path().glob(f"data/{directory}/{filename}.*"):
+        await filePath.unlink()
 
 
-def delete_all_folder_from_data(
+async def delete_all_folder_from_data(
     directory: str,
 ) -> None:
     """
     WARNING: this method should never be called with a directory based on user input.
     """
     path = Path(f"data/{directory}")
-    if Path.exists(path):
+    if await path.exists():
         shutil.rmtree(path)
 
 
@@ -479,7 +479,7 @@ async def generate_pdf_from_template(
     )
 
 
-def concat_pdf(
+async def concat_pdf(
     source_directory: str,
     source_filename: str | UUID,
     output_pdf: fitz.Document,
@@ -488,7 +488,7 @@ def concat_pdf(
     Add the content of the PDF file located in data to
     the `output_pdf` document.
     """
-    source_file_path = get_file_path_from_data(
+    source_file_path = await get_file_path_from_data(
         directory=source_directory,
         filename=source_filename,
     )
@@ -510,7 +510,7 @@ async def save_pdf_first_page_as_image(
     WARNING: **NEVER** trust user input when calling this function. Always check that parameters are valid.
     """
 
-    pdf_file_path = get_file_path_from_data(
+    pdf_file_path = await get_file_path_from_data(
         input_pdf_directory,
         filename,
         default_pdf_path,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ pytest-cov==7.1.0
 pytest-mock==3.15.1
 pytest==9.0.3
 ruff==0.11.8
-types-aiofiles==25.1.0.20260409
 types-Authlib==1.6.11.20260418
 types-fpdf2==2.8.4.20260408
 types-psutil==7.2.2.20260408

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiofiles==24.1.0                    # Asynchronous file manipulation
 alembic==1.18.4                     # database migrations
+anyio==4.13.0
 arq==0.28.0                         # Scheduler 
 asyncpg==0.31.0                     # PostgreSQL adapter for asynchronous operations
 authlib==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aiofiles==24.1.0                    # Asynchronous file manipulation
 alembic==1.18.4                     # database migrations
 anyio==4.13.0
 arq==0.28.0                         # Scheduler 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -295,8 +295,8 @@ async def test_compress_and_save_image_file() -> None:
             width=300,
             quality=85,
         )
-        assert Path(f"data/test/compressed/{valid_uuid}.webp").exists()
-        assert Path(f"data/test/compressed/original/{valid_uuid}.png").exists()
+        assert await Path(f"data/test/compressed/{valid_uuid}.webp").exists()
+        assert await Path(f"data/test/compressed/original/{valid_uuid}.png").exists()
 
 
 async def test_save_pdf_first_page_as_image() -> None:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,10 +1,11 @@
+import pathlib
 import shutil
 import uuid
 from io import BytesIO
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
+from anyio import Path
 from fastapi import HTTPException, UploadFile
 from PIL import Image
 from starlette.datastructures import Headers
@@ -73,7 +74,7 @@ async def init_objects() -> None:
 
 async def test_save_file() -> None:
     valid_uuid = str(uuid.uuid4())
-    with Path("assets/images/default_profile_picture.png").open("rb") as file:
+    with pathlib.Path("assets/images/default_profile_picture.png").open("rb") as file:
         await save_file_as_data(
             upload_file=UploadFile(
                 file,
@@ -88,7 +89,7 @@ async def test_save_file_with_invalid_content_type() -> None:
     valid_uuid = str(uuid.uuid4())
     with (
         pytest.raises(HTTPException, match="400: Invalid file format, supported*"),
-        Path("assets/images/default_profile_picture.png").open("rb") as file,
+        pathlib.Path("assets/images/default_profile_picture.png").open("rb") as file,
     ):
         await save_file_as_data(
             upload_file=UploadFile(
@@ -107,7 +108,7 @@ async def test_save_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
             FileNameIsNotAnUUIDError,
             match="The filename is not a valid UUID",
         ),
-        Path("assets/images/default_profile_picture.png").open("rb") as file,
+        pathlib.Path("assets/images/default_profile_picture.png").open("rb") as file,
     ):
         await save_file_as_data(
             upload_file=UploadFile(file),
@@ -118,7 +119,7 @@ async def test_save_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
 
 async def test_save_bytes() -> None:
     valid_uuid = str(uuid.uuid4())
-    with Path("assets/images/default_profile_picture.png").open("rb") as file:
+    with pathlib.Path("assets/images/default_profile_picture.png").open("rb") as file:
         await save_bytes_as_data(
             file_bytes=file.read(),
             directory="test",
@@ -134,7 +135,7 @@ async def test_save_bytes_raise_a_value_error_if_filename_isnt_an_uuid() -> None
             FileNameIsNotAnUUIDError,
             match="The filename is not a valid UUID",
         ),
-        Path("assets/images/default_profile_picture.png").open("rb") as file,
+        pathlib.Path("assets/images/default_profile_picture.png").open("rb") as file,
     ):
         await save_bytes_as_data(
             file_bytes=file.read(),
@@ -144,7 +145,7 @@ async def test_save_bytes_raise_a_value_error_if_filename_isnt_an_uuid() -> None
         )
 
 
-def test_get_existing_file_path_with_valid_uuid() -> None:
+async def test_get_existing_file_path_with_valid_uuid() -> None:
     valid_uuid = str(uuid.uuid4())
     default_asset = "assets/images/default_profile_picture.png"
     file_path = Path(f"data/test/{valid_uuid}.png")
@@ -152,7 +153,7 @@ def test_get_existing_file_path_with_valid_uuid() -> None:
         default_asset,
         file_path,
     )
-    returned_path = get_file_path_from_data(
+    returned_path = await get_file_path_from_data(
         directory="test",
         filename=valid_uuid,
         default_asset=default_asset,
@@ -160,9 +161,11 @@ def test_get_existing_file_path_with_valid_uuid() -> None:
     assert returned_path == file_path
 
 
-def test_get_non_existing_file_path_with_valid_uuid_return_default_asset() -> None:
+async def test_get_non_existing_file_path_with_valid_uuid_return_default_asset() -> (
+    None
+):
     valid_uuid = str(uuid.uuid4())
-    path = get_file_path_from_data(
+    path = await get_file_path_from_data(
         directory="test",
         filename=valid_uuid,
         default_asset="assets/images/default_profile_picture.png",
@@ -170,23 +173,23 @@ def test_get_non_existing_file_path_with_valid_uuid_return_default_asset() -> No
     assert path == Path("assets/images/default_profile_picture.png")
 
 
-def test_get_file_path_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
+async def test_get_file_path_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with pytest.raises(
         FileNameIsNotAnUUIDError,
         match="The filename is not a valid UUID",
     ):
-        get_file_path_from_data(
+        await get_file_path_from_data(
             directory="test",
             filename=not_a_uuid,
             default_asset="default_asset",
         )
 
 
-def test_get_file_with_valid_uuid() -> None:
+async def test_get_file_with_valid_uuid() -> None:
     valid_uuid = str(uuid.uuid4())
     default_asset = "assets/images/default_profile_picture.png"
-    file = get_file_from_data(
+    file = await get_file_from_data(
         directory="test",
         filename=valid_uuid,
         default_asset=default_asset,
@@ -194,20 +197,20 @@ def test_get_file_with_valid_uuid() -> None:
     assert file.path == Path(default_asset)
 
 
-def test_get_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
+async def test_get_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with pytest.raises(
         FileNameIsNotAnUUIDError,
         match="The filename is not a valid UUID",
     ):
-        get_file_from_data(
+        await get_file_from_data(
             directory="test",
             filename=not_a_uuid,
             default_asset="default_asset",
         )
 
 
-def test_delete_file_with_valid_uuid() -> None:
+async def test_delete_file_with_valid_uuid() -> None:
     valid_uuid = str(uuid.uuid4())
     default_asset = "assets/images/default_profile_picture.png"
     file_png_path = Path(f"data/test/{valid_uuid}.png")
@@ -222,21 +225,21 @@ def test_delete_file_with_valid_uuid() -> None:
         file_jpg_path,
     )
 
-    delete_file_from_data(
+    await delete_file_from_data(
         directory="test",
         filename=valid_uuid,
     )
-    assert not Path(file_png_path).is_file()
-    assert not Path(file_jpg_path).is_file()
+    assert not await Path(file_png_path).is_file()
+    assert not await Path(file_jpg_path).is_file()
 
 
-def test_delete_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
+async def test_delete_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     not_a_uuid = "not_a_uuid"
     with pytest.raises(
         FileNameIsNotAnUUIDError,
         match="The filename is not a valid UUID",
     ):
-        delete_file_from_data(
+        await delete_file_from_data(
             directory="test",
             filename=not_a_uuid,
         )
@@ -254,7 +257,9 @@ def test_delete_file_raise_a_value_error_if_filename_isnt_an_uuid() -> None:
     ],
 )
 async def test_compress(height: int, width: int) -> None:
-    with Path("assets/images/default_profile_picture.png").open("rb") as file:
+    with pathlib.Path("assets/images/default_profile_picture.png").open(
+        "rb",
+    ) as file:
         file_bytes = file.read()
         res = compress_image(
             file_bytes,
@@ -274,7 +279,7 @@ async def test_compress(height: int, width: int) -> None:
 
 async def test_compress_and_save_image_file() -> None:
     valid_uuid = str(uuid.uuid4())
-    with Path("assets/images/default_profile_picture.png").open("rb") as file:
+    with pathlib.Path("assets/images/default_profile_picture.png").open("rb") as file:
         await compress_and_save_image_file(
             upload_file=UploadFile(
                 file,
@@ -303,7 +308,7 @@ async def test_save_pdf_first_page_as_image() -> None:
         filename=valid_uuid,
         default_pdf_path="assets/pdf/default_pdf.pdf",
     )
-    assert Path(f"data/test/image/{valid_uuid}.jpg").is_file()
+    assert await Path(f"data/test/image/{valid_uuid}.jpg").is_file()
 
 
 async def test_get_core_data() -> None:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -124,7 +124,7 @@ async def test_save_bytes() -> None:
             file_bytes=file.read(),
             directory="test",
             filename=valid_uuid,
-            extension="png",
+            extension=ContentType.png,
         )
 
 
@@ -141,7 +141,7 @@ async def test_save_bytes_raise_a_value_error_if_filename_isnt_an_uuid() -> None
             file_bytes=file.read(),
             directory="test",
             filename=not_a_uuid,
-            extension="png",
+            extension=ContentType.png,
         )
 
 

--- a/tests/modules/test_raid.py
+++ b/tests/modules/test_raid.py
@@ -1,11 +1,11 @@
 import datetime
 import shutil
 import uuid
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 import pytest_asyncio
+from anyio import Path
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
@@ -204,8 +204,8 @@ async def init_objects() -> None:
 
     await add_object_to_db(validated_team)
 
-    Path("data/raid/").mkdir(parents=True, exist_ok=True)
-    default_asset = "assets/pdf/default_pdf.pdf"
+    await Path("data/raid/").mkdir(parents=True, exist_ok=True)
+    default_asset = "assets/pdf/default_PDF.pdf"
     expected_files = [
         "-1_ValidatedTeam_Captain_Validated.pdf",
         "-1_New Team_NoTeam_NoTeam.pdf",

--- a/tests/modules/test_raid.py
+++ b/tests/modules/test_raid.py
@@ -205,7 +205,7 @@ async def init_objects() -> None:
     await add_object_to_db(validated_team)
 
     await Path("data/raid/").mkdir(parents=True, exist_ok=True)
-    default_asset = "assets/pdf/default_PDF.pdf"
+    default_asset = "assets/pdf/default_pdf.pdf"
     expected_files = [
         "-1_ValidatedTeam_Captain_Validated.pdf",
         "-1_New Team_NoTeam_NoTeam.pdf",


### PR DESCRIPTION
# Description

## Summary
Based on https://github.com/aeecleclair/Hyperion/pull/985

- Starlette and FastAPI are based on [anyio](https://anyio.readthedocs.io/en/stable/), see [FastAPI documentation](https://fastapi.tiangolo.com/async/#write-your-own-async-code)
- use `anyio.Path` instead of `pathlib.Path`, see [ASYNC240](https://docs.astral.sh/ruff/rules/blocking-path-method-in-async-function/)
- remove `aiofiles` dependency in favor of `anyio`

<details>
<summary>

# Classification

</summary>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔨 Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] 🔧 Infra CI/CD (changes to configs of workflows)
- [ ] 💥 BREAKING CHANGE (fix or feature that require a new minimal version of the front-end)
- [ ] 😶‍🌫️ No impact for the end-users

## Impact & Scope

- [ ] Core functionality changes
- [ ] Single module changes
- [ ] Multiple modules changes
- [ ] Database migrations required
- [ ] Other: ... <!--Not module-oriented: write something!-->

## Testing

- [ ] 1. Tested this locally
- [ ] 2. Added/modified tests that pass the CI (or tested in a downstream fork)
- [ ] 3. Tested in a deployed pre-prod
- [ ] 0. Untestable (exceptionally), will be tested in prod directly

## Documentation

- [ ] Updated [the docs](docs.myecl.fr) accordingly : <!--[Docs#0 - Title](https://github.com/aeecleclair/myecl-documentation/pull/0)-->
- [ ] `"` Docstrings
- [ ] `#` Inline comments
- [ ] No documentation needed

</details>
